### PR TITLE
Admin Mode: teacher login required for register/unregister

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,17 +5,90 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Cookie, FastAPI, HTTPException, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+from typing import Optional
+import json
 import os
 from pathlib import Path
+import secrets
+import time
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
+TEACHERS_FILE = current_dir / "teachers.json"
+
+SESSION_COOKIE_NAME = "admin_session"
+SESSION_TTL_SECONDS = 60 * 60 * 8  # 8 hours
+_sessions = {}
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def _load_teachers() -> dict:
+    """Loads teacher credentials from a JSON file.
+
+    Expected format:
+    {"teachers": [{"username": "...", "password": "..."}]}
+    """
+    if not TEACHERS_FILE.exists():
+        return {}
+
+    try:
+        raw = json.loads(TEACHERS_FILE.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+
+    teachers = {}
+    for entry in raw.get("teachers", []):
+        username = str(entry.get("username", "")).strip()
+        password = str(entry.get("password", ""))
+        if username:
+            teachers[username] = password
+    return teachers
+
+
+def _get_teacher_from_session_token(token: Optional[str]) -> Optional[str]:
+    if not token:
+        return None
+    session = _sessions.get(token)
+    if not session:
+        return None
+    if time.time() > session.get("expires_at", 0):
+        _sessions.pop(token, None)
+        return None
+    return session.get("username")
+
+
+def _require_teacher(token: Optional[str]) -> str:
+    username = _get_teacher_from_session_token(token)
+    if not username:
+        raise HTTPException(status_code=401, detail="Teacher login required")
+    return username
+
+
+def _set_auth_cookie(response: Response, token: str):
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=token,
+        httponly=True,
+        samesite="lax",
+        max_age=SESSION_TTL_SECONDS,
+        path="/",
+    )
+
+
+def _clear_auth_cookie(response: Response):
+    response.delete_cookie(key=SESSION_COOKIE_NAME, path="/")
+
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
@@ -88,9 +161,42 @@ def get_activities():
     return activities
 
 
+@app.get("/auth/me")
+def auth_me(admin_session: Optional[str] = Cookie(default=None)):
+    username = _get_teacher_from_session_token(admin_session)
+    if not username:
+        return {"authenticated": False}
+    return {"authenticated": True, "username": username}
+
+
+@app.post("/auth/login")
+def auth_login(payload: LoginRequest, response: Response):
+    teachers = _load_teachers()
+    expected_password = teachers.get(payload.username)
+    if expected_password is None or expected_password != payload.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_urlsafe(32)
+    _sessions[token] = {
+        "username": payload.username,
+        "expires_at": time.time() + SESSION_TTL_SECONDS,
+    }
+    _set_auth_cookie(response, token)
+    return {"authenticated": True, "username": payload.username}
+
+
+@app.post("/auth/logout")
+def auth_logout(response: Response, admin_session: Optional[str] = Cookie(default=None)):
+    if admin_session:
+        _sessions.pop(admin_session, None)
+    _clear_auth_cookie(response)
+    return {"authenticated": False}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, admin_session: Optional[str] = Cookie(default=None)):
     """Sign up a student for an activity"""
+    _require_teacher(admin_session)
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +217,9 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, admin_session: Optional[str] = Cookie(default=None)):
     """Unregister a student from an activity"""
+    _require_teacher(admin_session)
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,103 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const signupLockedBanner = document.getElementById("signup-locked");
+
+  const userMenuButton = document.getElementById("user-menu-button");
+  const authModal = document.getElementById("auth-modal");
+  const authClose = document.getElementById("auth-close");
+  const authForm = document.getElementById("auth-form");
+  const authUsername = document.getElementById("auth-username");
+  const authPassword = document.getElementById("auth-password");
+  const authSubmit = document.getElementById("auth-submit");
+  const authLogout = document.getElementById("auth-logout");
+  const authStatus = document.getElementById("auth-status");
+  const authTitle = document.getElementById("auth-title");
+
+  let auth = { authenticated: false, username: null };
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function setSignupLocked(locked) {
+    if (locked) {
+      signupLockedBanner.classList.remove("hidden");
+    } else {
+      signupLockedBanner.classList.add("hidden");
+    }
+
+    signupForm
+      .querySelectorAll("input, select, button")
+      .forEach((el) => (el.disabled = locked));
+  }
+
+  function setAuthStatus(text, type) {
+    if (!text) {
+      authStatus.classList.add("hidden");
+      authStatus.textContent = "";
+      authStatus.className = "message hidden";
+      return;
+    }
+
+    authStatus.textContent = text;
+    authStatus.className = type;
+    authStatus.classList.remove("hidden");
+  }
+
+  function updateAuthUI() {
+    setSignupLocked(!auth.authenticated);
+
+    if (auth.authenticated) {
+      authTitle.textContent = "Teacher Account";
+      authSubmit.classList.add("hidden");
+      authLogout.classList.remove("hidden");
+      authUsername.disabled = true;
+      authPassword.disabled = true;
+      setAuthStatus(`Logged in as ${auth.username}`, "success");
+    } else {
+      authTitle.textContent = "Teacher Login";
+      authSubmit.classList.remove("hidden");
+      authLogout.classList.add("hidden");
+      authUsername.disabled = false;
+      authPassword.disabled = false;
+      setAuthStatus("", "");
+    }
+  }
+
+  function openAuthModal() {
+    authModal.classList.remove("hidden");
+    updateAuthUI();
+    if (!auth.authenticated) {
+      authPassword.value = "";
+      authUsername.focus();
+    }
+  }
+
+  function closeAuthModal() {
+    authModal.classList.add("hidden");
+  }
+
+  async function refreshAuth() {
+    try {
+      const response = await fetch("/auth/me", { credentials: "same-origin" });
+      const data = await response.json();
+      auth = {
+        authenticated: Boolean(data.authenticated),
+        username: data.username || null,
+      };
+    } catch (error) {
+      auth = { authenticated: false, username: null };
+      console.error("Error fetching auth state:", error);
+    }
+    updateAuthUI();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -14,6 +111,7 @@ document.addEventListener("DOMContentLoaded", () => {
       activitiesList.innerHTML = "";
 
       // Populate activities list
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");
         activityCard.className = "activity-card";
@@ -21,7 +119,8 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft =
           details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
+        // Create participants HTML. Only teachers can unregister.
+        const canManage = auth.authenticated;
         const participantsHTML =
           details.participants.length > 0
             ? `<div class="participants-section">
@@ -30,7 +129,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        canManage
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -57,9 +160,11 @@ document.addEventListener("DOMContentLoaded", () => {
       });
 
       // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
+      if (auth.authenticated) {
+        document.querySelectorAll(".delete-btn").forEach((button) => {
+          button.addEventListener("click", handleUnregister);
+        });
+      }
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -80,6 +185,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          credentials: "same-origin",
         }
       );
 
@@ -94,6 +200,10 @@ document.addEventListener("DOMContentLoaded", () => {
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
+
+        if (response.status === 401) {
+          openAuthModal();
+        }
       }
 
       messageDiv.classList.remove("hidden");
@@ -114,6 +224,12 @@ document.addEventListener("DOMContentLoaded", () => {
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
+    if (!auth.authenticated) {
+      showMessage("Teacher login required to register students.", "error");
+      openAuthModal();
+      return;
+    }
+
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
@@ -124,6 +240,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          credentials: "same-origin",
         }
       );
 
@@ -139,6 +256,10 @@ document.addEventListener("DOMContentLoaded", () => {
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
+
+        if (response.status === 401) {
+          openAuthModal();
+        }
       }
 
       messageDiv.classList.remove("hidden");
@@ -156,5 +277,67 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
-  fetchActivities();
+  userMenuButton.addEventListener("click", openAuthModal);
+  authClose.addEventListener("click", closeAuthModal);
+  authModal.addEventListener("click", (event) => {
+    if (event.target === authModal) {
+      closeAuthModal();
+    }
+  });
+
+  authForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (auth.authenticated) {
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: authUsername.value,
+          password: authPassword.value,
+        }),
+      });
+      const result = await response.json();
+
+      if (!response.ok) {
+        setAuthStatus(result.detail || "Login failed", "error");
+        return;
+      }
+
+      auth = {
+        authenticated: true,
+        username: result.username,
+      };
+      updateAuthUI();
+      closeAuthModal();
+      fetchActivities();
+      showMessage(`Logged in as ${auth.username}`, "success");
+    } catch (error) {
+      setAuthStatus("Login failed. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  authLogout.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        credentials: "same-origin",
+      });
+    } catch (error) {
+      console.error("Error logging out:", error);
+    }
+
+    auth = { authenticated: false, username: null };
+    updateAuthUI();
+    closeAuthModal();
+    fetchActivities();
+    showMessage("Logged out", "info");
+  });
+
+  refreshAuth().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,9 @@
   </head>
   <body>
     <header>
+      <button id="user-menu-button" class="header-user-button" type="button" aria-label="Teacher login">
+        👤
+      </button>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>
@@ -23,6 +26,9 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <div id="signup-locked" class="info hidden">
+          Teacher login required to register or unregister students.
+        </div>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -44,6 +50,32 @@
     <footer>
       <p>&copy; 2023 Mergington High School</p>
     </footer>
+
+    <div id="auth-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="auth-title">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 id="auth-title">Teacher Login</h3>
+          <button id="auth-close" class="icon-btn" type="button" aria-label="Close">✕</button>
+        </div>
+
+        <div id="auth-status" class="message hidden"></div>
+
+        <form id="auth-form">
+          <div class="form-group">
+            <label for="auth-username">Username:</label>
+            <input id="auth-username" name="username" autocomplete="username" required />
+          </div>
+          <div class="form-group">
+            <label for="auth-password">Password:</label>
+            <input id="auth-password" name="password" type="password" autocomplete="current-password" required />
+          </div>
+          <div class="modal-actions">
+            <button id="auth-submit" type="submit">Log in</button>
+            <button id="auth-logout" class="secondary-btn hidden" type="button">Log out</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,6 +22,84 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
+}
+
+.header-user-button {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: white;
+  width: 40px;
+  height: 36px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.header-user-button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.icon-btn {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 6px 8px;
+  border-radius: 4px;
+}
+
+.icon-btn:hover {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.secondary-btn {
+  background-color: #ffffff;
+  color: #1a237e;
+  border: 1px solid #1a237e;
+}
+
+.secondary-btn:hover {
+  background-color: #f5f5f5;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 999;
+}
+
+.modal-content {
+  width: 100%;
+  max-width: 420px;
+  background-color: white;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
 }
 
 header h1 {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,8 @@
+{
+  "teachers": [
+    {
+      "username": "teacher",
+      "password": "changeme"
+    }
+  ]
+}


### PR DESCRIPTION
Implements **Admin Mode** (issue #5): only teachers can register/unregister students.

## What changed
- Added `/auth/login`, `/auth/logout`, `/auth/me` with an HttpOnly cookie session.
- Protected `POST /activities/{activity_name}/signup` and `DELETE /activities/{activity_name}/unregister` (401 when not logged in).
- Added a header user icon + login modal; signup/unregister controls are disabled/hidden for non-teachers.
- Added `src/teachers.json` for teacher credentials (default: `teacher` / `changeme`).

## How to test
1. Open the site: you should be able to view activities + participant lists.
2. Try signing up or clicking ❌ while logged out: you should be blocked.
3. Click the 👤 icon, log in, then signup/unregister should work.
